### PR TITLE
Integrate group management into main controls

### DIFF
--- a/Source/BDTHPlugin/Interface/PluginUI.cs
+++ b/Source/BDTHPlugin/Interface/PluginUI.cs
@@ -1,6 +1,4 @@
 using BDTHPlugin.Interface.Windows;
-using BDTHPlugin.Services;
-
 using Dalamud.Interface.Windowing;
 
 namespace BDTHPlugin.Interface
@@ -13,7 +11,6 @@ namespace BDTHPlugin.Interface
 
     public readonly MainWindow Main;
     public readonly DebugWindow Debug = new();
-    public readonly GroupWindow Group;
     public readonly FurnitureList Furniture = new();
 
     public PluginUI()
@@ -22,9 +19,6 @@ namespace BDTHPlugin.Interface
       Windows.AddWindow(Main);
       Windows.AddWindow(Debug);
       Windows.AddWindow(Furniture);
-
-      Group = new GroupWindow(Plugin.GetGroups());
-      Windows.AddWindow(Group);
     }
 
     public void Draw()


### PR DESCRIPTION
## Summary
- integrate group service accessors and updating
- add housing item selection helper
- support group pivot editing through gizmo
- refactor main window into Controls and Groups tabs

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6897e0f035ac8328b6d932fa48bfed26