### PR TITLE
Log exceptions when selecting items

### DIFF
--- a/Source/Fantabode/PluginMemory.cs
+++ b/Source/Fantabode/PluginMemory.cs
@@ -135,10 +135,17 @@ namespace Fantabode
     public SelectItemDelegate SelectItem = null!;
 
     public unsafe void SelectHousingItem(HousingItem* item)
-{
-  if (HousingStructure == null || item == null) return;
-  try { SelectItem((IntPtr)HousingStructure, (IntPtr)item); } catch { }
-}
+    {
+      if (HousingStructure == null || item == null) return;
+      try
+      {
+        SelectItem((IntPtr)HousingStructure, (IntPtr)item);
+      }
+      catch (Exception ex)
+      {
+        Plugin.Log.Error(ex, "Error while selecting housing item");
+      }
+    }
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
## Summary
- log failures when selecting housing items to aid troubleshooting

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `/tmp/dotnet/dotnet build` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f5911ed48328a903569400400df5