### PR TITLE
Check housing permissions before enabling Place Anywhere

### DIFF
--- a/Source/Fantabode/Interface/Windows/MainWindow.cs
+++ b/Source/Fantabode/Interface/Windows/MainWindow.cs
@@ -78,14 +78,21 @@ namespace Fantabode.Interface.Windows
         DrawError("No housing permissions");
       ImGui.BeginDisabled(!hasPerms);
 
-      var placeAnywhere = Configuration.PlaceAnywhere;
-      if (ImGui.Checkbox("Place Anywhere", ref placeAnywhere))
-      {
-        Memory.SetPlaceAnywhere(placeAnywhere);
-        Configuration.PlaceAnywhere = placeAnywhere;
-        Configuration.Save();
-      }
-      DrawTooltip("Allows the placement of objects without limitation from the game engine.");
+        var placeAnywhere = Configuration.PlaceAnywhere;
+        if (ImGui.Checkbox("Place Anywhere", ref placeAnywhere))
+        {
+          if (hasPerms)
+          {
+            Memory.SetPlaceAnywhere(placeAnywhere);
+            Configuration.PlaceAnywhere = placeAnywhere;
+            Configuration.Save();
+          }
+          else
+          {
+            Plugin.Chat.PrintError("No housing permissions");
+          }
+        }
+        DrawTooltip("Allows the placement of objects without limitation from the game engine.");
 
       ImGui.SameLine();
 

--- a/Source/Fantabode/PluginMemory.cs
+++ b/Source/Fantabode/PluginMemory.cs
@@ -198,7 +198,16 @@ namespace Fantabode
         var config = Plugin.GetConfiguration();
 
         if (config.PlaceAnywhere)
-          SetPlaceAnywhere(Plugin.GetConfiguration().PlaceAnywhere);
+        {
+          unsafe
+          {
+            var mgr = HousingMgr;
+            if (mgr != null && mgr->HasHousePermissions())
+              SetPlaceAnywhere(Plugin.GetConfiguration().PlaceAnywhere);
+            else
+              Plugin.Chat.PrintError("No housing permissions");
+          }
+        }
       }
       catch (Exception ex)
       {
@@ -222,7 +231,9 @@ namespace Fantabode
       try
       {
         // Disable the place anywhere in case it's on.
-        SetPlaceAnywhere(false);
+        var mgr = HousingMgr;
+        if (mgr != null && mgr->HasHousePermissions())
+          SetPlaceAnywhere(false);
 
                 // Enable the housing goods menu again.
                 if (HousingGoods != null) ;// HousingGoods->IsVisible = true;//same as above, this value is read only with dalamud 13


### PR DESCRIPTION
## Summary
- Guard calls to `SetPlaceAnywhere` with housing permission checks and show an error if permissions are missing.
- Avoid disabling place-anywhere during disposal unless housing permissions are available.

## Testing
- `dotnet build` *(fails: command not found)*
- `sudo apt-get install -y dotnet-sdk-6.0` *(fails: Package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_6897fb76b344832894131efcf1331c24