### PR TITLE
Fix HousingGoods visibility guards

### DIFF
--- a/Source/Fantabode/PluginMemory.cs
+++ b/Source/Fantabode/PluginMemory.cs
@@ -217,8 +217,10 @@ namespace Fantabode
 
     public unsafe void ShowFurnishingList(bool state)
     {
-            if (HousingGoods != null)
-                ;//HousingGoods->IsVisible = state;//same as above, this value is read only with dalamud 13
+      if (HousingGoods != null)
+      {
+        // HousingGoods->IsVisible = state; // TODO: re-enable when writable
+      }
     }
 
     public void ShowInventory(bool state) => InventoryVisible = state;
@@ -235,8 +237,11 @@ namespace Fantabode
         if (mgr != null && mgr->HasHousePermissions())
           SetPlaceAnywhere(false);
 
-                // Enable the housing goods menu again.
-                if (HousingGoods != null) ;// HousingGoods->IsVisible = true;//same as above, this value is read only with dalamud 13
+        // Enable the housing goods menu again.
+        if (HousingGoods != null)
+        {
+          // HousingGoods->IsVisible = true; // TODO: re-enable when writable
+        }
       }
       catch (Exception ex)
       {


### PR DESCRIPTION
## Summary
- Wrap `HousingGoods` visibility toggles in comment blocks instead of empty statements
- Add TODOs to re-enable visibility once writable

## Testing
- `~/.dotnet/dotnet build Source/Fantabode.sln` *(fails: Dalamud.NET.Sdk: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_689803bfb8ec8328b8b9f5c4342bf1d6