### PR TITLE
Refine group selection and use repository icon

### DIFF
--- a/Source/Fantabode/Fantabode.json
+++ b/Source/Fantabode/Fantabode.json
@@ -1,25 +1,25 @@
 {
-  "Author": "LeonBlade",
+  "Author": "Blink",
   "Name": "Fantabode",
   "InternalName": "Fantabode",
   "AssemblyVersion": "1.6.9.0",
   "Description": "Move around housing items with coordinates and allows you to place anywhere.",
   "ApplicableVersion": "any",
-  "RepoUrl": "https://github.com/LeonBlade/Fantabode",
+    "RepoUrl": "https://github.com/jackandcarter/Fantabode",
   "Tags": [
     "fantabode",
     "housing",
     "decorating",
     "placement",
     "gizmo",
-    "LeonBlade"
+    "Blink"
   ],
   "DalamudApiLevel": 13,
   "LoadRequiredState": 0,
   "LoadSync": false,
   "CanUnloadAsync": false,
   "LoadPriority": 0,
-  "IconUrl": "https://raw.githubusercontent.com/LeonBlade/Fantabode/main/icon.png",
+    "IconUrl": "https://raw.githubusercontent.com/jackandcarter/Fantabode/main/Source/icon.png",
   "Punchline": "House decorating made easy!",
   "AcceptsFeedback": true
 }

--- a/Source/Fantabode/Groups/Group.cs
+++ b/Source/Fantabode/Groups/Group.cs
@@ -12,14 +12,25 @@ namespace Fantabode.Groups
     public readonly IReadOnlyList<ulong> ItemIds; // (ulong)HousingItem* pointers
     public readonly IReadOnlyList<Matrix4x4> LocalFromPivot; // itemLocal = inv(pivotWorld) * itemWorld
     public readonly Matrix4x4 PivotWorld; // capture-time pivot
+    public readonly IReadOnlyList<Vector3> StartPositions;
+    public IReadOnlyList<Vector3>? EndPositions { get; private set; }
 
-    public Group(PivotMode pivot, IReadOnlyList<ulong> itemIds, IReadOnlyList<Matrix4x4> localFromPivot, in Matrix4x4 pivotWorld)
+    public Group(
+      PivotMode pivot,
+      IReadOnlyList<ulong> itemIds,
+      IReadOnlyList<Matrix4x4> localFromPivot,
+      in Matrix4x4 pivotWorld,
+      IReadOnlyList<Vector3> startPositions)
     {
       if (itemIds.Count != localFromPivot.Count) throw new ArgumentException("Mismatched lists");
       Pivot = pivot;
       ItemIds = itemIds;
       LocalFromPivot = localFromPivot;
       PivotWorld = pivotWorld;
+      StartPositions = startPositions;
     }
+
+    public void SetEndPositions(IReadOnlyList<Vector3> end)
+      => EndPositions = end;
   }
 }

--- a/Source/Fantabode/Interface/Windows/MainWindow.cs
+++ b/Source/Fantabode/Interface/Windows/MainWindow.cs
@@ -260,11 +260,15 @@ namespace Fantabode.Interface.Windows
               if (Plugin.TryGetYardObject(items[i].HousingRowId, out var yard)) { name = yard.Item.Value.Name.ToString(); icon = yard.Item.Value.Icon; }
               if (Plugin.TryGetFurnishing(items[i].HousingRowId, out var furn)) { name = furn.Item.Value.Name.ToString(); icon = furn.Item.Value.Icon; }
               if (icon != 0) { Plugin.DrawIcon(icon, new Vector2(18,18)); ImGui.SameLine(); }
-              ImGui.TextUnformatted(name == string.Empty ? $"(Row {items[i].HousingRowId})" : name);
+              var display = name == string.Empty ? $"(Row {items[i].HousingRowId})" : name;
+              if (_checked[itemId]) ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.4f, 1f, 0.4f, 1f));
+              var selected = Groups.SelectedId == itemId;
+              if (ImGui.Selectable(display, selected)) Groups.SelectGroupItem(itemId);
+              if (_checked[itemId]) ImGui.PopStyleColor();
 
               ImGui.TableNextColumn();
               var flag = _checked[itemId];
-              if (ImGui.Checkbox($"##sel{i}", ref flag)) _checked[itemId] = flag;
+              if (ImGui.Checkbox($"##sel{i}", ref flag)) { _checked[itemId] = flag; if (flag) Groups.SelectGroupItem(itemId); }
             }
             ImGui.EndTable();
           }


### PR DESCRIPTION
## Summary
- Point manifest to jackandcarter repo and Source icon.png
- Track grouped items with start/end coords and selected item state
- Highlight grouped items and select them to drive gizmo movement

## Testing
- `dotnet build` *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68980d4a6ef48328a6a9d7dac786b950