### PR TITLE
Add group preview transforms for gizmo dragging

### DIFF
--- a/Source/Fantabode/Interface/Gizmo.cs
+++ b/Source/Fantabode/Interface/Gizmo.cs
@@ -129,6 +129,7 @@ namespace Fantabode.Interface
         m.M31 = cx*sy*cz + sx*sz; m.M32 = cx*sy*sz - sx*cz; m.M33 = cx*cy;
         m.Translation = translate;
         Groups.SetPreviewPivotWorld(m);
+        Groups.Preview();
         return;
       }
       Memory.WritePosition(translate);


### PR DESCRIPTION
## Summary
- compute per-item preview transforms and end positions in GroupService
- preview group movement by writing temporary transforms during gizmo drag

## Testing
- `dotnet build -warnaserror Source/Fantabode.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68981f801cf08328a795d5fa4d78fab1