### PR TITLE
Add group preview bounding box overlay

### DIFF
--- a/Source/Fantabode/Interface/Gizmo.cs
+++ b/Source/Fantabode/Interface/Gizmo.cs
@@ -25,6 +25,7 @@ namespace Fantabode.Interface
 
     private ImGuiIOPtr Io;
     private Vector2 Wp;
+    private readonly GroupPreviewOverlay previewOverlay = new();
 
     public void Draw()
     {
@@ -79,6 +80,7 @@ namespace Fantabode.Interface
       ImGuizmo.SetOrthographic(false);
 
       ImGuizmo.SetRect(pos.X, pos.Y, size.X, size.Y);
+      previewOverlay.Draw(view, proj, pos, size);
 
       ComposeMatrix();
 

--- a/Source/Fantabode/Interface/GroupPreviewOverlay.cs
+++ b/Source/Fantabode/Interface/GroupPreviewOverlay.cs
@@ -1,0 +1,62 @@
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+using Fantabode.Services;
+
+namespace Fantabode.Interface
+{
+  public sealed class GroupPreviewOverlay
+  {
+    private static GroupService Groups => Plugin.GetGroups();
+
+    public void Draw(in Matrix4x4 view, in Matrix4x4 proj, in Vector2 pos, in Vector2 size)
+    {
+      if (!Groups.ApplyGizmoToGroup || Groups.Current is null)
+        return;
+      var bounds = Groups.PreviewBounds;
+      if (bounds is null)
+        return;
+      var (min, max) = bounds.Value;
+
+      var vp = view * proj;
+      Span<Vector2> corners2d = stackalloc Vector2[8];
+      Span<Vector3> corners = stackalloc Vector3[8]
+      {
+        new(min.X, min.Y, min.Z),
+        new(max.X, min.Y, min.Z),
+        new(max.X, max.Y, min.Z),
+        new(min.X, max.Y, min.Z),
+        new(min.X, min.Y, max.Z),
+        new(max.X, min.Y, max.Z),
+        new(max.X, max.Y, max.Z),
+        new(min.X, max.Y, max.Z)
+      };
+      for (int i = 0; i < 8; i++)
+      {
+        if (!WorldToScreen(corners[i], vp, pos, size, out corners2d[i]))
+          return;
+      }
+
+      var drawList = ImGui.GetWindowDrawList();
+      uint col = ImGui.GetColorU32(new Vector4(1f, 1f, 0f, 1f));
+      void Line(int a, int b) => drawList.AddLine(corners2d[a], corners2d[b], col);
+      Line(0, 1); Line(1, 2); Line(2, 3); Line(3, 0);
+      Line(4, 5); Line(5, 6); Line(6, 7); Line(7, 4);
+      Line(0, 4); Line(1, 5); Line(2, 6); Line(3, 7);
+    }
+
+    private static bool WorldToScreen(in Vector3 world, in Matrix4x4 vp, in Vector2 pos, in Vector2 size, out Vector2 screen)
+    {
+      var clip = Vector4.Transform(new Vector4(world, 1f), vp);
+      if (clip.W <= 0f)
+      {
+        screen = Vector2.Zero;
+        return false;
+      }
+      var ndc = clip / clip.W;
+      screen = new Vector2(
+        pos.X + (ndc.X * 0.5f + 0.5f) * size.X,
+        pos.Y + (0.5f - ndc.Y * 0.5f) * size.Y);
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- compute preview bounds for grouped items and clear during apply/clear
- render group preview bounding box in new GroupPreviewOverlay
- hook overlay into gizmo to show while manipulating group

## Testing
- `dotnet build Source/Fantabode/Fantabode.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689820b4ce288328aae1f4ee8a86be0e