### PR TITLE
Capture and preview group item rotations

### DIFF
--- a/Source/Fantabode/Groups/Group.cs
+++ b/Source/Fantabode/Groups/Group.cs
@@ -13,24 +13,34 @@ namespace Fantabode.Groups
     public readonly IReadOnlyList<Matrix4x4> LocalFromPivot; // itemLocal = inv(pivotWorld) * itemWorld
     public readonly Matrix4x4 PivotWorld; // capture-time pivot
     public readonly IReadOnlyList<Vector3> StartPositions;
+    public readonly IReadOnlyList<Vector3> StartRotations;
     public IReadOnlyList<Vector3>? EndPositions { get; private set; }
+    public IReadOnlyList<Vector3>? EndRotations { get; private set; }
 
     public Group(
       PivotMode pivot,
       IReadOnlyList<ulong> itemIds,
       IReadOnlyList<Matrix4x4> localFromPivot,
       in Matrix4x4 pivotWorld,
-      IReadOnlyList<Vector3> startPositions)
+      IReadOnlyList<Vector3> startPositions,
+      IReadOnlyList<Vector3> startRotations)
     {
-      if (itemIds.Count != localFromPivot.Count) throw new ArgumentException("Mismatched lists");
+      if (itemIds.Count != localFromPivot.Count ||
+          itemIds.Count != startPositions.Count ||
+          itemIds.Count != startRotations.Count)
+        throw new ArgumentException("Mismatched lists");
       Pivot = pivot;
       ItemIds = itemIds;
       LocalFromPivot = localFromPivot;
       PivotWorld = pivotWorld;
       StartPositions = startPositions;
+      StartRotations = startRotations;
     }
 
     public void SetEndPositions(IReadOnlyList<Vector3> end)
       => EndPositions = end;
+
+    public void SetEndRotations(IReadOnlyList<Vector3> end)
+      => EndRotations = end;
   }
 }


### PR DESCRIPTION
## Summary
- track start and end rotations for grouped items
- capture rotations during selection and compute them for preview and apply

## Testing
- `dotnet build Fantabode.sln` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68982254ca588328bf0a34b741413984