### PR TITLE
Fix missing System namespace for Span in group overlay

### DIFF
--- a/Source/Fantabode/Interface/GroupPreviewOverlay.cs
+++ b/Source/Fantabode/Interface/GroupPreviewOverlay.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
 using Fantabode.Services;


### PR DESCRIPTION
## Summary
- import System namespace so GroupPreviewOverlay can use Span types

## Testing
- `dotnet build -c Debug -p:EnableWindowsTargeting=true` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6898161cb8ec8328b50777403f0f9ddd